### PR TITLE
Update 031_root_navigation_sample.sh

### DIFF
--- a/scripts/031_root_navigation_sample.sh
+++ b/scripts/031_root_navigation_sample.sh
@@ -18,8 +18,6 @@ then
 type = "menu-item"
 target = "_blank"
 url = "../neteyeshare/"
-[root@neteye4vm2 root]# pwd
-/neteye/shared/icingaweb2/conf/preferences/root
 EOM
 
 else


### PR DESCRIPTION
These two lines break IcingaWeb2, not allowing the creation of another navigation resource.
I think are not needed.