### PR TITLE
Fix bug in check_logstash_queue caused by version 7.10.x of Elasticse…

### DIFF
--- a/monitoring/monitoring-plugins/elk/logstash/check_logstash_queue.sh
+++ b/monitoring/monitoring-plugins/elk/logstash/check_logstash_queue.sh
@@ -206,7 +206,7 @@ if [[ "${LOGSTASH_VERSION}" == "auto" ]]; then
       exit ${UNKNOWN}
     fi
 
-    LOGSTASH_VERSION=$(echo ${BASIC_INFO} | jq -r ".version" | sed  "s/\([0-9]\)\.[0-9]\.[0-9]/\1/")
+    LOGSTASH_VERSION=$(echo ${BASIC_INFO} | jq -r ".version" | sed -r "s:([0-9]).[0-9]+.[0-9]:\1:" )
 fi
 
 case "${LOGSTASH_VERSION}" in


### PR DESCRIPTION
…arch

Update the script to use a pattern that supports numbers with more than one cipher in the minor version